### PR TITLE
client: expose network namespace CNI config as task env vars.

### DIFF
--- a/client/allocrunner/alloc_runner.go
+++ b/client/allocrunner/alloc_runner.go
@@ -769,6 +769,12 @@ func (ar *allocRunner) SetNetworkStatus(s *structs.AllocNetworkStatus) {
 	ar.stateLock.Lock()
 	defer ar.stateLock.Unlock()
 	ar.state.NetworkStatus = s.Copy()
+
+	// Iterate each task runner and add the status information. This allows the
+	// task to build the environment variables with this information available.
+	for _, tr := range ar.tasks {
+		tr.SetNetworkStatus(s.Copy())
+	}
 }
 
 func (ar *allocRunner) NetworkStatus() *structs.AllocNetworkStatus {

--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -237,6 +237,12 @@ type TaskRunner struct {
 	networkIsolationLock sync.Mutex
 	networkIsolationSpec *drivers.NetworkIsolationSpec
 
+	// allocNetworkStatus is provided from the allocrunner and allows us to
+	// include this information as env vars for the task. When manipulating
+	// this the allocNetworkStatusLock should be used.
+	allocNetworkStatusLock sync.Mutex
+	allocNetworkStatus     *structs.AllocNetworkStatus
+
 	allocHookResources *cstructs.AllocHookResources
 }
 
@@ -1327,6 +1333,19 @@ func (tr *TaskRunner) SetNetworkIsolation(n *drivers.NetworkIsolationSpec) {
 	tr.networkIsolationLock.Lock()
 	tr.networkIsolationSpec = n
 	tr.networkIsolationLock.Unlock()
+}
+
+// SetNetworkStatus is called from the allocrunner to propagate the
+// network status of an allocation. This call occurs once the network hook has
+// run and allows this information to be exported as env vars within the
+// taskenv.
+func (tr *TaskRunner) SetNetworkStatus(s *structs.AllocNetworkStatus) {
+	tr.allocNetworkStatusLock.Lock()
+	tr.allocNetworkStatus = s
+	tr.allocNetworkStatusLock.Unlock()
+
+	// Update the taskenv builder.
+	tr.envBuilder = tr.envBuilder.SetNetworkStatus(s)
 }
 
 // triggerUpdate if there isn't already an update pending. Should be called

--- a/client/taskenv/env_test.go
+++ b/client/taskenv/env_test.go
@@ -753,6 +753,61 @@ func TestEnvironment_Upstreams(t *testing.T) {
 	require.Equal(t, "1234", env["bar"])
 }
 
+func Test_addNetNamespacePort(t *testing.T) {
+	testCases := []struct {
+		inputPorts     structs.AllocatedPorts
+		inputNetwork   *structs.AllocNetworkStatus
+		expectedOutput map[string]string
+		name           string
+	}{
+		{
+			inputPorts: structs.AllocatedPorts{
+				{Label: "http", To: 80},
+			},
+			inputNetwork: &structs.AllocNetworkStatus{
+				InterfaceName: "eth0",
+				Address:       "172.26.64.11",
+			},
+			expectedOutput: map[string]string{
+				"NOMAD_ALLOC_INTERFACE_http": "eth0",
+				"NOMAD_ALLOC_IP_http":        "172.26.64.11",
+				"NOMAD_ALLOC_ADDR_http":      "172.26.64.11:80",
+				"NOMAD_ALLOC_PORT_http":      "80",
+			},
+			name: "single input port",
+		},
+		{
+			inputPorts: structs.AllocatedPorts{
+				{Label: "http", To: 80},
+				{Label: "https", To: 443},
+			},
+			inputNetwork: &structs.AllocNetworkStatus{
+				InterfaceName: "eth0",
+				Address:       "172.26.64.11",
+			},
+			expectedOutput: map[string]string{
+				"NOMAD_ALLOC_INTERFACE_http":  "eth0",
+				"NOMAD_ALLOC_IP_http":         "172.26.64.11",
+				"NOMAD_ALLOC_ADDR_http":       "172.26.64.11:80",
+				"NOMAD_ALLOC_PORT_http":       "80",
+				"NOMAD_ALLOC_INTERFACE_https": "eth0",
+				"NOMAD_ALLOC_IP_https":        "172.26.64.11",
+				"NOMAD_ALLOC_ADDR_https":      "172.26.64.11:443",
+				"NOMAD_ALLOC_PORT_https":      "443",
+			},
+			name: "multiple input ports",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			inputMap := make(map[string]string)
+			addNetNamespacePort(inputMap, tc.inputPorts, tc.inputNetwork)
+			assert.Equal(t, tc.expectedOutput, inputMap, tc.name)
+		})
+	}
+}
+
 func TestEnvironment_SetPortMapEnvs(t *testing.T) {
 	envs := map[string]string{
 		"foo":            "bar",

--- a/e2e/networking/networking.go
+++ b/e2e/networking/networking.go
@@ -92,3 +92,27 @@ func (tc *NetworkingE2ETest) TestNetworking_DockerBridgedHostnameInterpolation(f
 	f.NoError(err, "failed to run hostname exec command")
 	f.Contains(hostsOutput, "mylittlepony-0", "/etc/hosts doesn't contain hostname entry")
 }
+
+func (tc *NetworkingE2ETest) TestNetworking_DockerBridgedCNIEnvVars(f *framework.F) {
+
+	jobID := "test-networking-" + uuid.Generate()[0:8]
+	f.NoError(e2eutil.Register(jobID, "networking/inputs/docker_bridged_basic.nomad"))
+	tc.jobIDs = append(tc.jobIDs, jobID)
+	f.NoError(e2eutil.WaitForAllocStatusExpected(jobID, "default", []string{"running"}),
+		"job should be running with 1 alloc")
+
+	// Grab the allocations for the job.
+	allocs, _, err := tc.Nomad().Jobs().Allocations(jobID, false, nil)
+	f.NoError(err, "failed to get allocs for job")
+	f.Len(allocs, 1, "job should have one alloc")
+
+	// Run the env command within the allocation.
+	envOutput, err := e2eutil.AllocExec(allocs[0].ID, "sleep", "env", "default", nil)
+	f.NoError(err, "failed to run env exec command")
+
+	// Check all the network namespace env vars are present.
+	f.Contains("NOMAD_ALLOC_INTERFACE_http", envOutput, "namespace interface env var not found")
+	f.Contains("NOMAD_ALLOC_IP_http", envOutput, "namespace ip env var not found")
+	f.Contains("NOMAD_ALLOC_PORT_http", envOutput, "namespace port env var not found")
+	f.Contains("NOMAD_ALLOC_ADDR_http", envOutput, "namespace addr env var not found")
+}


### PR DESCRIPTION
This change exposes CNI configuration details of a network
namespace as environment variables. This allows a task to use
these value to configure itself; a potential use case is to run
a Raft application binding to IP and Port details configured using
the bridge network mode.